### PR TITLE
fix file form macro class name

### DIFF
--- a/resources/macros/form.php
+++ b/resources/macros/form.php
@@ -25,7 +25,7 @@ Form::macro('myFile', function ($name, $label="", $options=[]) {
     return "
         <div class='form-group'>
             ". $label .
-              Form::file($name, array_merge(["class" => "form-control"], $options)). "
+              Form::file($name, array_merge(["class" => "form-control-file"], $options)). "
         </div>
     ";
 });


### PR DESCRIPTION
Replaced form-control class name to form-control-file

[https://getbootstrap.com/docs/4.1/components/forms/#form-controls](url)


