### PR TITLE
Refactor head into reusable template

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ Password: 123456
 
 ### RTL support
 
-Uncomment [this](https://github.com/kossa/laradminator/blob/master/resources/views/admin/default.blade.php#L15) line and you have the RTL version
+Uncomment [this](https://github.com/kossa/laradminator/blob/master/resources/views/layouts/partials/head.blade.php#L12) line and you have the RTL version
 
 ![alt text](https://content.screencast.com/users/kouycela/folders/Jing/media/0d4f930b-9605-4c9e-9847-e9278235481c/00001832.png  "Logo Title Text 1")
  

--- a/resources/views/admin/default.blade.php
+++ b/resources/views/admin/default.blade.php
@@ -1,22 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
 
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-    <!-- CSRF Token -->
-    <meta name="csrf-token" content="{{ csrf_token() }}">
-
-    <title>{{ config('app.name', 'Laravel') }}</title>
-
-    <!-- Styles -->
-	<link href="{{ mix('/css/app.css') }}" rel="stylesheet"> 
-	{{-- <link href="{{ mix('/css/rtl.css') }}" rel="stylesheet">  --}}
-	
-	@yield('css')
-
-</head>
+@include('layouts.partials.head')
 
 <body class="app">
 
@@ -38,8 +23,8 @@
 
                         <h4 class="c-grey-900 mT-10 mB-30">@yield('page-header')</h4>
 
-						@include('admin.partials.messages') 
-						@yield('content')
+                        @include('admin.partials.messages')
+                        @yield('content')
 
                     </div>
                 </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,34 +1,25 @@
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+@include('layouts.partials.head')
 
-  <!-- CSRF Token -->
-  <meta name="csrf-token" content="{{ csrf_token() }}">
-
-  <title>{{ config('app.name', 'Laravel') }}</title>
-
-  <!-- Styles -->
-  <link href="{{ asset('/css/app.css') }}" rel="stylesheet">
-</head>
 <body class="app">
 
-    @include('admin.partials.spinner')
+  @include('admin.partials.spinner')
 
-    <div class="peers ai-s fxw-nw h-100vh">
-      <div class="d-n@sm- peer peer-greed h-100 pos-r bgr-n bgpX-c bgpY-c bgsz-cv" style='background-image: url("/images/bg.jpg")'>
-        <div class="pos-a centerXY">
-          <div class="bgc-white bdrs-50p pos-r" style='width: 120px; height: 120px;'>
-            <img class="pos-a centerXY" src="/images/logo.png" alt="">
-          </div>
+  <div class="peers ai-s fxw-nw h-100vh">
+    <div class="d-n@sm- peer peer-greed h-100 pos-r bgr-n bgpX-c bgpY-c bgsz-cv"
+      style='background-image: url("/images/bg.jpg")'>
+      <div class="pos-a centerXY">
+        <div class="bgc-white bdrs-50p pos-r" style='width: 120px; height: 120px;'>
+          <img class="pos-a centerXY" src="/images/logo.png" alt="">
         </div>
       </div>
-      <div class="col-12 col-md-4 peer pX-40 pY-80 h-100 bgc-white scrollable pos-r" style='min-width: 320px;'>
-        @yield('content')
-      </div>
     </div>
-  
+    <div class="col-12 col-md-4 peer pX-40 pY-80 h-100 bgc-white scrollable pos-r" style='min-width: 320px;'>
+      @yield('content')
+    </div>
+  </div>
+
 </body>
+
 </html>

--- a/resources/views/layouts/partials/head.blade.php
+++ b/resources/views/layouts/partials/head.blade.php
@@ -1,0 +1,16 @@
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- CSRF Token -->
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    <title>{{ config('app.name', 'Laravel') }}</title>
+
+    <!-- Styles -->
+    <link href="{{ mix('/css/app.css') }}" rel="stylesheet">
+    <link href="{{ mix('/css/rtl.css') }}" rel="stylesheet">
+
+    @yield('css')
+
+</head>


### PR DESCRIPTION
Refactor head tag's content of both app.blade.php and default.blade.php into 
/resources/views/layouts/partials/head.blade.php
to enable RTL support even in the login page(the picture should be on the right side when using RTL)

Before(by uncommenting the rtl line): 
![image](https://user-images.githubusercontent.com/32931114/89107459-1cca7780-d429-11ea-982d-2f2990027d8c.png)
 After(just by uncommenting the rtl line):
![image](https://user-images.githubusercontent.com/32931114/89107488-4d121600-d429-11ea-886f-d58c614cc024.png)
