### PR TITLE
update user rules

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -47,8 +47,9 @@ class User extends Authenticatable
     public static function rules($update = false, $id = null)
     {
         $common = [
-            'email'    => "required|email|unique:users,email,$id",
-            'password' => 'nullable|confirmed',
+            'email'=> ['required', 'email', 'unique:users,email,'.$id],
+            'name'=> 'required',
+            'password' => ['required', 'confirmed'],
             'avatar' => 'image',
         ];
 


### PR DESCRIPTION
i think the password should be required or you will get this error [ SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'password' cannot be null (SQL: update `users` set `password` = ?, `users`.`updated_at` = 2021-06-19 17:54:41 where `id` = 1) ] and this make sense , another solution is to don't send "password" key if it's null  to the update method inside UserController , same things to username ( name )